### PR TITLE
Android10でダウンロードフォルダを開けない問題を修正

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <uses-permission android:name="com.android.vending.BILLING" />
     <application
         android:usesCleartextTraffic="true"
+        android:requestLegacyExternalStorage="true"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"


### PR DESCRIPTION
### 状況
Android10でダウンロードフォルダを開けず、「このフォルダにアクセスする権限がありません」と表示されます。

デバッグしたところ、FileListAdapterのコンストラクタでFile.listFiles()がnullを返しています。

これはAPIレベル29にて追加された「対象範囲別ストレージ」の影響と思われます。

### 修正内容
[対象範囲別ストレージを一時的にオプトアウトする](https://developer.android.com/training/data-storage/use-cases?hl=ja#opt-out-scoped-storage)ことで適切な動作を確認できました。